### PR TITLE
Add "Yii::$app->end();" after redirect

### DIFF
--- a/LocaleUrls.php
+++ b/LocaleUrls.php
@@ -124,6 +124,7 @@ class LocaleUrls extends Component
                     $url .= "?$queryString";
                 }
                 Yii::$app->getResponse()->redirect($url);
+                Yii::$app->end();
             }
             $request->setPathInfo($pathInfo);
         } else {
@@ -160,6 +161,7 @@ class LocaleUrls extends Component
             $url = rtrim($request->getUrl(), '/');
             $url = $length ? substr_replace($url, "/$language", $length, 0) : "/$language$url";
             Yii::$app->getResponse()->redirect($url);
+            Yii::$app->end();
         }
     }
 }


### PR DESCRIPTION
To avoid the "*$application->run();*" after the redirect.

Without the *end()* call, the page will be rendered but not show because of the "302" of the answer, than it will be rendered again.

This's a big wasting resources and, that was my the problem, "burn" the flash messages.






