### PR TITLE
add slug routes feature

### DIFF
--- a/UrlManager.php
+++ b/UrlManager.php
@@ -224,7 +224,7 @@ class UrlManager extends BaseUrlManager
             $params = (array) $params;
             $route = trim($params[0], '/');
             foreach ($this->slugRoutes as $pattern => $slug) {
-                if (preg_match($pattern, $route)) {
+                if (preg_match("#^$pattern#", $route)) {
                     return parent::createUrl($params[$slug]);
                 }
             }

--- a/UrlManager.php
+++ b/UrlManager.php
@@ -95,6 +95,38 @@ class UrlManager extends BaseUrlManager
     public $ignoreLanguageUrlPatterns = [];
 
     /**
+     * @var array list of route and its parameter used as slug URL handler. The keys of the array are routes,
+     * the values are query parameter:
+     *
+     * ~~~php
+     * [
+     *      'site/index' => 'slug'
+     * ]
+     * ~~~
+     *
+     * Route rules will be added at initial procedure to handle all requests as:
+     *
+     * ~~~php
+     * 'rules' => [
+     *       '<slug:.+>' => 'site/index',
+     * ]
+     * ~~~
+     *
+     * Route patterns are checked during URL creation. If a pattern matches, language parameter will be skipped
+     * as in $ignoreLanguageUrlPatterns case and slug query string will be used as argument for parent::createUrl()
+     * when enableDefaultLanguageUrlCode is false to avoid wrong URL without default language code but with slug
+     * query string instead after redirect, e.g:
+     *
+     *   slug route:       '<slug:.+>' => 'site/index'
+     *   default language: ru
+     *   start slug url:   site.com/en/some/slug/url
+     *   change language:  site.com/ru/some/slug/url
+     *   redirect to:      site.com/site/index/?slug=some%2Fslug%2Furl
+     *   should be:        site.com/some/slug/url
+     */
+    public $slugRoutes = [];
+
+    /**
      * @var string the language that was initially set in the application configuration
      */
     protected $_defaultLanguage;
@@ -129,6 +161,11 @@ class UrlManager extends BaseUrlManager
         if ($this->enableLocaleUrls && $this->languages) {
             if (!$this->enablePrettyUrl) {
                 throw new InvalidConfigException('Locale URL support requires enablePrettyUrl to be set to true.');
+            }
+        }
+        if ($this->slugRoutes) {
+            foreach($this->slugRoutes as $pattern => $slug) {
+                $this->addRules(["<$slug:.+>" => $pattern]);
             }
         }
         $this->_defaultLanguage = Yii::$app->language;
@@ -179,6 +216,16 @@ class UrlManager extends BaseUrlManager
             foreach ($this->ignoreLanguageUrlPatterns as $pattern => $v) {
                 if (preg_match($pattern, $route)) {
                     return parent::createUrl($params);
+                }
+            }
+        }
+
+        if ($this->slugRoutes && !$this->enableDefaultLanguageUrlCode) {
+            $params = (array) $params;
+            $route = trim($params[0], '/');
+            foreach ($this->slugRoutes as $pattern => $slug) {
+                if (preg_match($pattern, $route)) {
+                    return parent::createUrl($params[$slug]);
                 }
             }
         }


### PR DESCRIPTION
Hello, I am newbie at github and here is my first try and I am sorry if I doing something wrong.
So, I am using codemix/yii2-localeurls and everything works perfect, but one day I needed to have some sort of Semantic URL with i18n support, so I just add rule to handle all requests at corresponding controller/action. and during simple opening such slug URL there is no problem, but in case when enableDefaultLanguageUrlCode is set to its default false, when I am switching from any other language to default language, there is one redirection that use createUrl(), and when language code is skipped from url there was one problem with query string parameter used in rule. As it comes as argument to parent::createUrl($params), so instead of getting correct url I've got urlencoded string as parameter and route part in url.

For example i have slug rule:
  '<slug:.+>' => 'site/index'

and default language: 
  ru

when I open slug url:
  site.com/en/some/slug/url

and then I am trying to change language in my language switcher. I open:
  site.com/ru/some/slug/url

so createUrl() will make url which used in redirectToLanguage() so I go to:
  site.com/site/index/?slug=some%2Fslug%2Furl

but for my case it should be:
  site.com/some/slug/url

So now with this feature it is possible. And I also create rule at run-time for slug Url based on config parameters. I am still not sure that I made it correctly and hope that at least I did not damage anything else.
thank you in advance for any review and thoughts about it.