### PR TITLE
Fix error on redirect to //

### DIFF
--- a/UrlManager.php
+++ b/UrlManager.php
@@ -247,7 +247,12 @@ class UrlManager extends BaseUrlManager
                     }
                 }
                 $needleLength = strlen($needle);
-                return $needleLength ? substr_replace($url, "$needle/$language", 0, $needleLength) : "/$language$url";
+                $cleanUrl = $needleLength ? substr_replace($url, "$needle/$language", 0, $needleLength) : "/$language$url";
+                if (substr($cleanUrl, 0, 2) == '//') {
+                    Yii::trace("Cleaning...", __METHOD__);
+                    $cleanUrl = str_replace("//", "/", $cleanUrl);
+                }
+                return $cleanUrl;
             }
         } else {
             return parent::createUrl($params);

--- a/UrlManager.php
+++ b/UrlManager.php
@@ -430,6 +430,9 @@ class UrlManager extends BaseUrlManager
         if ($this->suffix==='/' && $route==='') {
             $url = rtrim($url, '/').'/';
         }
+        if (substr($url, 0, 2) == '//') {
+            $url = str_replace("//", "/", $url);
+        }
         Yii::trace("Redirecting to $url.", __METHOD__);
         Yii::$app->getResponse()->redirect($url);
         if (YII_ENV_TEST) {


### PR DESCRIPTION
Not sure why, but when i load http://domain.ltd or http://domain.ltd/, it redirects to /es/site/index, instead of http://domain.ltd/es/site/index

Trace log: [trace][codemix\localeurls\UrlManager::redirectToLanguage] Redirecting to //es/site/index.

PR fix that problem cleaning url if it starts on //