### PR TITLE
fixed composer dependency to yiisoft/yii2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-      "yiisoft/yii2": "*"
+      "yiisoft/yii2": ">=2.0.10"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
fixes #91
version to `>=2.0.10` for $normalizer property from yii UrlManager

https://github.com/yiisoft/yii2/blob/master/framework/web/UrlManager.php#L148

I would suggest tagging a `1.5.0`