### PR TITLE
fix to handle different url rules in different languages for the same action

### DIFF
--- a/UrlManager.php
+++ b/UrlManager.php
@@ -244,9 +244,10 @@ class UrlManager extends BaseUrlManager
             $isLanguageGiven = isset($params[$this->languageParam]);
             $language = $isLanguageGiven ? $params[$this->languageParam] : Yii::$app->language;
             $isDefaultLanguage = $language === $this->getDefaultLanguage();
+            $isLinkRefersToBaseUrl = empty($params[0]);
 
-            if ($isLanguageGiven) {
-                unset($params[$this->languageParam]);
+            if (!$isLanguageGiven && !$isLinkRefersToBaseUrl) {
+                $params[$this->languageParam] = $language;
             }
 
             $url = parent::createUrl($params);


### PR DESCRIPTION
related to #129 

I have tried to use different urls in different languages which are points to a static controller/action route.

With this modification and the following url rules it is working well.
Order of the language related url rules is matter.
Default language comes first then the rules for other languages.

```php
    ...
    'urlManager' => [
        'class' => '\codemix\localeurls\UrlManager',
        'languages' => ['en', 'hu'],
        'enablePrettyUrl' => true,
        'showScriptName' => false,
        'rules' => [
            '/'           => 'frontend/default/landing',
            [
                'pattern' => '/jatek',
                'route' => 'frontend/default/game',
                'defaults' => ['language' => 'hu'],
            ],
            [
                'pattern' => '/feliratkozas',
                'route' => 'frontend/default/subscribe',
                'defaults' => ['language' => 'hu'],
            ],
            [
                'pattern' => '/game',
                'route' => 'frontend/default/game',
                'defaults' => ['language' => 'en'],
            ],
            [
                'pattern' => '/subscribe',
                'route' => 'frontend/default/subscribe',
                'defaults' => ['language' => 'en'],
            ],
        ],
    ],
    ...
```

I cannot manage to run tests locally, I will check this in travis.