### PR TITLE
Fix Url Matching for similar patterns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ install:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - travis_retry composer install --prefer-dist --no-interaction --no-progress
 
-before_script:
-  - echo "output_buffering=On" > my-php-config.ini
-  - phpenv config-add my-php-config.ini
+script:
+  - php -doutput_buffering=On `which phpunit`
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,7 @@ install:
   - travis_retry composer clear-cache
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - travis_retry composer install --prefer-dist --no-interaction --no-progress
+
+before_script:
+  - echo "output_buffering=On" > my-php-config.ini
+  - phpenv config-add my-php-config.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ install:
   - travis_retry composer clear-cache
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - travis_retry composer install --prefer-dist --no-interaction --no-progress
+  - travis_retry composer require --dev phpunit/phpunit:^6.0 --prefer-dist --no-interaction --no-progress
 
 script:
-  - php -doutput_buffering=On $(which phpunit)
+  - php -doutput_buffering=On vendor/bin/phpunit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ install:
   - travis_retry composer install --prefer-dist --no-interaction --no-progress
 
 script:
-  - php -doutput_buffering=On `which phpunit`
+  - php -doutput_buffering=On $(which phpunit)
 

--- a/README.md
+++ b/README.md
@@ -145,8 +145,7 @@ language code are no longer accessible:
 ### Language Configuration
 
 All languages **including the default language** must be configured in the `languages`
-parameter of the `localeUrls` component. You should list more specific language
-codes before the similar looking generic ones (i.e. 'en-US' before 'en'):
+parameter of the `localeUrls` component:
 
     'languages' => ['en-US', 'en-UK', 'en', 'fr', 'de-AT', 'de'],
 

--- a/UrlManager.php
+++ b/UrlManager.php
@@ -352,6 +352,15 @@ class UrlManager extends BaseUrlManager
                 $parts[] = $value;
             }
         }
+        // order by length to make longer patterns match before short patterns, e.g. put "en-GB" before "en"
+        usort($parts, function($a, $b) {
+            $la = mb_strlen($a);
+            $lb = mb_strlen($b);
+            if ($la === $lb) {
+                return 0;
+            }
+            return $la < $lb ? 1 : -1;
+        });
         $pattern = implode('|', $parts);
         if (preg_match("#^($pattern)\b(/?)#i", $pathInfo, $m)) {
             $this->_request->setPathInfo(mb_substr($pathInfo, mb_strlen($m[1].$m[2])));

--- a/tests/UrlManagerTest.php
+++ b/tests/UrlManagerTest.php
@@ -33,6 +33,21 @@ class UrlManagerTest extends TestCase
         $this->assertEquals('site/page', $request->pathInfo);
     }
 
+    public function testSetsLanguageFromUrlOrder()
+    {
+        $this->mockUrlManager([
+            'languages' => ['en', 'en-US', 'de'],
+        ]);
+        $this->mockRequest('/en-us/site/page');
+        $this->assertEquals('en-US', Yii::$app->language);
+        $this->assertEquals('en-US', Yii::$app->session->get('_language'));
+        $cookie = Yii::$app->response->cookies->get('_language');
+        $this->assertNotNull($cookie);
+        $this->assertEquals('en-US', $cookie->value);
+        $request = Yii::$app->request;
+        $this->assertEquals('site/page', $request->pathInfo);
+    }
+
     public function testSetsLanguageFromUrlIfUppercaseEnabled()
     {
         $this->mockUrlManager([


### PR DESCRIPTION
currently the order in which available languages are defined influences the way URL patterns are matched,
if I specify `en` before `en-GB` the matching will always find `en` in the URL but never `en-GB`. Changing the pattern to match
longer patterns first fixes this.