### PR TITLE
Added a parameter of the language

### DIFF
--- a/UrlManager.php
+++ b/UrlManager.php
@@ -389,6 +389,7 @@ class UrlManager extends BaseUrlManager
                 }
             }
             Yii::$app->language = $language;
+            $this->languageValue=$language;
             Yii::trace("Language code found in URL. Setting application language to '$language'.", __METHOD__);
             if ($this->enableLanguagePersistence) {
                 $this->persistLanguage($language);

--- a/UrlManager.php
+++ b/UrlManager.php
@@ -119,6 +119,11 @@ class UrlManager extends BaseUrlManager
      * configuration
      */
     protected $_defaultLanguage;
+    
+    /**
+     * @var string indicates the language of formation of the URL
+     */
+    public $languageValue;
 
     /**
      * @inheritdoc
@@ -175,6 +180,7 @@ class UrlManager extends BaseUrlManager
                 throw new InvalidConfigException('Locale URL support requires enablePrettyUrl to be set to true.');
             }
         }
+        $this->languageValue = Yii::$app->language;
         $this->_defaultLanguage = Yii::$app->language;
         parent::init();
     }
@@ -244,7 +250,7 @@ class UrlManager extends BaseUrlManager
             $isLanguageGiven = isset($params[$this->languageParam]);
             $language = $isLanguageGiven ? $params[$this->languageParam] : Yii::$app->language;
             $isDefaultLanguage = $language === $this->getDefaultLanguage();
-
+            $this->languageValue=$language;
             if ($isLanguageGiven) {
                 unset($params[$this->languageParam]);
             }


### PR DESCRIPTION
After processing the URL, there is no parameter in which language the page is formed.
It is very necessary if you use your own rules for forming a page in different languages.
Maybe you should change the name of the parameter