### PR TITLE
Configurable language redirect

### DIFF
--- a/UrlManager.php
+++ b/UrlManager.php
@@ -625,7 +625,7 @@ class UrlManager extends BaseUrlManager
             return;
         }
         Yii::trace("Redirecting to $url.", __METHOD__);
-        Yii::$app->getResponse()->redirect($url);
+        Yii::$app->getResponse()->redirect($url, 301);
         if (YII2_LOCALEURLS_TEST) {
             // Response::redirect($url) above will call `Url::to()` internally.
             // So to really test for the same final redirect URL here, we need

--- a/UrlManager.php
+++ b/UrlManager.php
@@ -156,6 +156,12 @@ class UrlManager extends BaseUrlManager
     public $geoIpLanguageCountries = [];
 
     /**
+     * @var int the HTTP status code.
+     * Defaults is 302.
+     */
+    public $languageRedirectCode = 302;
+
+    /**
      * @var \yii\web\Request
      */
     protected $_request;
@@ -625,7 +631,7 @@ class UrlManager extends BaseUrlManager
             return;
         }
         Yii::trace("Redirecting to $url.", __METHOD__);
-        Yii::$app->getResponse()->redirect($url, 301);
+        Yii::$app->getResponse()->redirect($url, $this->languageRedirectCode);
         if (YII2_LOCALEURLS_TEST) {
             // Response::redirect($url) above will call `Url::to()` internally.
             // So to really test for the same final redirect URL here, we need


### PR DESCRIPTION
Fix 302 default redirect to 301.

`    public function redirect($url, $statusCode = 302, $checkAjax = true)
`

A 301 redirect, or also known as a permanent redirect, should be put in place to permanently redirect a page.