### PR TITLE
Preserve numeric keys.

### DIFF
--- a/UrlManager.php
+++ b/UrlManager.php
@@ -617,8 +617,7 @@ class UrlManager extends BaseUrlManager
             $params[$this->languageParam] = $language;
         }
         // See Yii Issues #8291 and #9161:
-        $params = $params + $this->_request->getQueryParams();
-        array_unshift($params, $route);
+        $params = [$route] + $params + $this->_request->getQueryParams();
         $url = $this->createUrl($params);
         // Required to prevent double slashes on generated URLs
         if ($this->suffix === '/' && $route === '' && count($params) === 1) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | unknown

array_unshift not preserve numeric keys.